### PR TITLE
Add brine_init_keypair_from_seed function

### DIFF
--- a/include/brine.h
+++ b/include/brine.h
@@ -30,6 +30,7 @@ void brine_init(brine_memory_cb_s *cb);
 
 brine_keypair_s *brine_new_keypair();
 bool brine_init_keypair(brine_keypair_s *keypair);
+bool brine_init_keypair_from_seed(brine_keypair_s *keypair, const unsigned char *seed, size_t seedlen);
 void brine_sign_message(const brine_keypair_s *keypair, const unsigned char *message, size_t msglen, unsigned char *buf);
 bool brine_verify_signature(const unsigned char *key, const unsigned char *message, size_t msglen, unsigned char *signature);
 

--- a/src/brine.c
+++ b/src/brine.c
@@ -47,6 +47,14 @@ bool brine_init_keypair(brine_keypair_s *keypair) {
   return true;
 }
 
+bool brine_init_keypair_from_seed(brine_keypair_s *keypair, const unsigned char *seed, size_t seedlen) {
+  if (seedlen != BRINE_SEED_SZ) {
+    return false;
+  }
+  ed25519_create_keypair(keypair->public_key, keypair->private_key, seed);
+  return true;
+}
+
 brine_keypair_s *brine_new_keypair() {
   brine_keypair_s *retval = (brine_keypair_s *) brine_alloc(sizeof(brine_keypair_s));
   if (retval) {


### PR DESCRIPTION
From https://github.com/kevsmith/libbrine/pull/4

This allows you to generate a keypair given a pre-existing secret. You
need to provide it with a 32-byte binary term.
